### PR TITLE
Brought over Drivers folder from SoarOperatingSystem

### DIFF
--- a/UARTDriver/Inc/UARTDriver.hpp
+++ b/UARTDriver/Inc/UARTDriver.hpp
@@ -1,0 +1,90 @@
+#ifndef CUBE_UART_DRIVER_HPP_
+#define CUBE_UART_DRIVER_HPP_
+/**
+ ******************************************************************************
+ * File Name          : UARTDriver.hpp
+ * Description        : UART Driver
+ *        Uses the STM32 LL library
+ * Author             : cjchanx (Chris)
+ ******************************************************************************
+*/
+
+/* Includes ------------------------------------------------------------------*/
+#include "SystemDefines.hpp"
+#include "cmsis_os.h"
+
+// Example code on how to declare UART Driver Instances in the HPP
+#if EXAMPLE_CODE
+/* UART Driver Instances ------------------------------------------------------------------*/
+class UARTDriver;
+
+namespace Driver {
+	extern UARTDriver uart1;
+	extern UARTDriver uart2;
+	extern UARTDriver uart3;
+	extern UARTDriver uart5;
+}
+
+/* UART Driver Aliases ------------------------------------------------------------------*/
+namespace UART {
+	constexpr UARTDriver* Umbilical_RCU = &Driver::uart1;
+	constexpr UARTDriver* Radio = &Driver::uart2;
+	constexpr UARTDriver* Conduit_PBB = &Driver::uart3;
+	// UART 4 (GPS) uses HAL
+	constexpr UARTDriver* Debug = &Driver::uart5;
+}
+#endif
+
+/* UART Receiver Base Class ------------------------------------------------------------------*/
+/**
+ * @brief Any classes that are expected to receive using a UART driver
+ *		  must derive from this base class and provide an implementation
+ *		  for InterruptRxData
+ */
+class UARTReceiverBase
+{
+public:
+	virtual void InterruptRxData(uint8_t errors) = 0;
+};
+
+
+/* UART Driver Class ------------------------------------------------------------------*/
+/**
+ * @brief This is a basic UART driver designed for Interrupt Rx and Polling Tx
+ *	      based on the STM32 LL Library
+ */
+class UARTDriver
+{
+public:
+	UARTDriver(USART_TypeDef* uartInstance) :
+		kUart_(uartInstance),
+		rxCharBuf_(nullptr),
+		rxReceiver_(nullptr) {}
+
+	// Polling Functions
+	bool Transmit(uint8_t* data, uint16_t len);
+
+	// Interrupt Functions
+	bool ReceiveIT(uint8_t* charBuf, UARTReceiverBase* receiver);
+
+
+	// Interrupt Handlers
+	void HandleIRQ_UART(); // This MUST be called inside USARTx_IRQHandler
+
+protected:
+	// Helper Functions
+	bool HandleAndClearRxError();
+	bool GetRxErrors();
+
+
+	// Constants
+	USART_TypeDef* kUart_; // Stores the UART instance
+
+	// Variables
+	uint8_t* rxCharBuf_; // Stores a pointer to the buffer to store the received data
+	UARTReceiverBase* rxReceiver_; // Stores a pointer to the receiver object
+};
+
+
+
+#endif // CUBE_UART_DRIVER_HPP_

--- a/UARTDriver/UARTDriver.cpp
+++ b/UARTDriver/UARTDriver.cpp
@@ -1,0 +1,132 @@
+/**
+ ******************************************************************************
+ * File Name          : UARTDriver.cpp
+ * Description        : UART Driver
+ * Author             : cjchanx (Chris)
+ ******************************************************************************
+ *
+ * Notes:
+ * If further efficiency is required, DMA can be used to transmit and receive.
+ * A good reference for this is MaJerle's STM32 USART DMA RX/TX example
+ * https://github.com/MaJerle/stm32-usart-uart-dma-rx-tx/blob/main/projects/usart_rx_idle_line_irq_rtos_F4/Src/main.c
+ *
+ ******************************************************************************
+*/
+#include "UARTDriver.hpp"
+
+/**
+ * @brief Transmits data via polling
+ * @param data The data to transmit
+ * @param len The length of the data to transmit
+ * @return True if the transmission was successful, false otherwise
+ */
+bool UARTDriver::Transmit(uint8_t* data, uint16_t len)
+{
+    // Loop through and transmit each byte via. polling
+    for (uint16_t i = 0; i < len; i++) {
+        LL_USART_TransmitData8(kUart_, data[i]);
+
+        // Wait until the TX Register Empty Flag is set
+        while (!LL_USART_IsActiveFlag_TXE(kUart_)) {}
+    }
+
+    // Wait until the transfer complete flag is set
+    while (!LL_USART_IsActiveFlag_TC(kUart_)) {}
+
+    return true;
+}
+
+/**
+* @brief Receives 1 byte of data via interrupt
+* @param receiver
+* @return TRUE if interrupt was successfully enabled, FALSE otherwise
+*/
+bool UARTDriver::ReceiveIT(uint8_t* charBuf, UARTReceiverBase* receiver)
+{
+    // Check flags
+    HandleAndClearRxError();
+    if (LL_USART_IsActiveFlag_RXNE(kUart_)) {
+        // Read the data and ignore it
+        LL_USART_ReceiveData8(kUart_);
+    }
+
+    // Set the buffer and receiver
+    rxCharBuf_ = charBuf;
+    rxReceiver_ = receiver;
+
+    // Enable the receive interrupt
+    LL_USART_EnableIT_RXNE(kUart_);
+
+    return true;
+}
+
+/**
+ * @brief Clears any error flags that may have been set
+ * @return true if flags had to be cleared, false otherwise
+ */
+bool UARTDriver::HandleAndClearRxError()
+{
+    bool shouldClearFlags = false;
+    if (LL_USART_IsActiveFlag_ORE(kUart_)) {
+        shouldClearFlags = true;
+    }
+    if (LL_USART_IsActiveFlag_NE(kUart_)) {
+        shouldClearFlags = true;
+    }
+    if(LL_USART_IsActiveFlag_FE(kUart_)) {
+        shouldClearFlags = true;
+    }
+    if(LL_USART_IsActiveFlag_PE(kUart_)) {
+        shouldClearFlags = true;
+    }
+
+    // Clearing the ORE here also clears PE, NE, FE, IDLE
+    if(shouldClearFlags)
+        LL_USART_ClearFlag_ORE(kUart_);
+
+    return !shouldClearFlags;
+}
+
+/**
+ * @brief Checks UART Rx error flags, if any are set returns true
+ * @return true if any error flags are set, false otherwise
+ */
+bool UARTDriver::GetRxErrors()
+{
+    bool hasErrors = false;
+
+    if (LL_USART_IsActiveFlag_ORE(kUart_)) {
+        hasErrors = true;
+    }
+    else if (LL_USART_IsActiveFlag_NE(kUart_)) {
+        hasErrors = true;
+    }
+    else if(LL_USART_IsActiveFlag_FE(kUart_)) {
+        hasErrors = true;
+    }
+    else if(LL_USART_IsActiveFlag_PE(kUart_)) {
+        hasErrors = true;
+    }
+
+    return hasErrors;
+}
+
+/**
+ * @brief Handles an interrupt for the UART
+ * @attention MUST be called inside USARTx_IRQHandler
+ */
+void UARTDriver::HandleIRQ_UART()
+{
+    // Call the callback if RXNE is set
+    if (LL_USART_IsActiveFlag_RXNE(kUart_)) {
+        // Read the data from the data register
+        if (rxCharBuf_ != nullptr) {
+            *rxCharBuf_ = LL_USART_ReceiveData8(kUart_);
+        }
+
+        // Call the receiver interrupt
+        if(rxReceiver_ != nullptr) {
+            rxReceiver_->InterruptRxData(GetRxErrors());
+        }
+    }
+}

--- a/UARTDriver/UARTDriver_README.md
+++ b/UARTDriver/UARTDriver_README.md
@@ -1,0 +1,105 @@
+# UART Driver
+
+## Usage
+### 1 Changing STM32 UART Line from HAL to UART
+- First ensure the .ioc indicates the UART line is enabled
+- (Note this was done in the Cube++ setup previously) Second go to the **Project Manager** tab at the top, under UART select the UART lines you want to use the driver and change them to use the LL library.
+- Lastly ensure the UART Global Interrupt for any lines you want to use the driver for is enabled (TODO: Add screenshot)
+
+### 2 Defining and Initializing UART Driver Instances
+
+- Inside a .hpp file setup something like this, with names/number of drivers changed for however many uart lines you want
+- I recommended setting up a section for aliases so you can reference a driver simply by doing UART::Debug-> for example
+```C++
+/* UART Driver Instances ------------------------------------------------------------------*/
+class UARTDriver;
+
+namespace Driver {
+	extern UARTDriver lpuart1;
+	extern UARTDriver uart1;
+	extern UARTDriver uart2;
+	extern UARTDriver uart3;
+}
+
+/* UART Driver Aliases ------------------------------------------------------------------*/
+namespace UART {
+	constexpr UARTDriver* RPI = &Driver::lpuart1; // UART Link to Raspberry Pi
+	constexpr UARTDriver* SOB = &Driver::uart1;
+	constexpr UARTDriver* Umbilical_DMB = &Driver::uart2;
+	constexpr UARTDriver* Radio = &Driver::uart3;
+
+	constexpr UARTDriver* Debug = &Driver::uart2;
+}
+```
+
+Inside a `.cpp` file setup something like this, with names/number of drivers changed for however many uart lines you want
+```C++
+// Declare the global UART driver objects
+namespace Driver {
+    UARTDriver lpuart1(LPUART1);
+    UARTDriver uart1(USART1);
+    UARTDriver uart2(USART2);
+    UARTDriver uart3(USART3);
+}
+```
+
+Inside a RunInterface file or equivalent (a file that gives C functions access to C++ functions without name problems) define a function called
+something like cpp_USART5_IRQHandler(), for example:
+```C++
+/*
+ *  RunInterface.cpp
+ */
+
+#include "main_system.hpp"
+#include "UARTDriver.hpp"
+
+extern "C" {
+    void run_interface()
+    {
+        run_main();
+    }
+
+    void cpp_USART5_IRQHandler()
+    {
+        Driver::uart5.HandleIRQ_UART();
+    }
+}
+
+```
+```C++
+
+/*
+ * RunInterface.hpp
+ */
+
+#ifndef C__IFACE_HPP_
+#define C__IFACE_HPP_
+
+void run_interface();
+
+void cpp_USART5_IRQHandler();
+
+#endif /* C__IFACE_HPP_ */
+
+```
+
+In this case you must call cpp_USART5_IRQHandler() inside Core/Src/stm32##xx_it.c where ## is the processor family. For example:
+```C++
+/**
+  * @brief This function handles USART2 global interrupt.
+  */
+void USART2_IRQHandler(void)
+{
+  /* USER CODE BEGIN USART2_IRQn 0 */
+
+  /* USER CODE END USART2_IRQn 0 */
+  /* USER CODE BEGIN USART2_IRQn 1 */
+  cpp_USART2_IRQHandler();
+  /* USER CODE END USART2_IRQn 1 */
+}
+```
+
+
+
+
+


### PR DESCRIPTION
* Should be identical to the drivers folder from SoarOperating system. 
* At least in AvionicsTemplateRepository, requires adding include paths to the compilers:
  "${workspace_loc:/${ProjName}/SoarCommunications}"
  "${workspace_loc:/${ProjName}/SoarCommunications/UART}"
  "${workspace_loc:/${ProjName}/SoarCommunications/UART/Inc}"