### PR TITLE
Add CanAutoNode from the PeripheralDriversSubmodule

### DIFF
--- a/CanAutoNode/CanAutoNode.cpp
+++ b/CanAutoNode/CanAutoNode.cpp
@@ -1,0 +1,342 @@
+/*
+ * CanAutoNode.cpp
+ *
+ *  Created on: Jul 16, 2025
+ *      Author: Adam Godin
+ */
+
+#include <CanAutoNode.hpp>
+#include <cstring>
+
+
+
+CanAutoNode::~CanAutoNode() {
+
+}
+
+/* Converts a byte sequence into a 32-bit integer (big-endian).
+ * @param in Pointer to the beginning of the input bytes. Must be at least four bytes in length.
+ * @return 32-bit integer represented by the four input bytes.
+ */
+uint32_t CanAutoNode::shift8to32(const uint8_t *in) {
+	return (static_cast<uint32_t>(in[0])<<24) | (static_cast<uint32_t>(in[1])<<16) | (static_cast<uint32_t>(in[2])<<8) | in[3];
+}
+
+/* Converts a byte sequence into a 16-bit integer (big-endian).
+ * @param in Pointer to the beginning of the input bytes. Must be at least two bytes in length.
+ * @return 16-bit integer represented by the two input bytes.
+ */
+uint16_t CanAutoNode::shift8to16(const uint8_t *in) {
+	return (static_cast<uint16_t>(in[0])<<8) | in[1];
+}
+
+/* Checks if there is overlap between two ranges. Note that range start is inclusive and range end is exclusive.
+ * @param a First range.
+ * @param b Second range.
+ * @return true if there is any overlap.
+ */
+bool CanAutoNode::IDRangesOverlap(IDRange a, IDRange b) {
+	return a.start < b.end && a.end > b.start;
+}
+
+/* Converts a byte sequence into a Node struct.
+ * @param msg Input byte sequence. Must be as large as a Node struct.
+ * @return Node represented by the bytes.
+ */
+CanAutoNode::Node CanAutoNode::nodeFromMsg(const uint8_t *msg) {
+
+	return MsgToData<Node>(msg);
+
+}
+
+/* Converts a 32-bit integer into a byte sequence (big-endian).
+ * @param in 32-bit integer to convert.
+ * @param out Pointer to output buffer where the integer will be written. Must be four bytes long.
+ */
+void CanAutoNode::shift32to8(uint32_t in, uint8_t *out) {
+	memcpy(out,&in,sizeof(in));
+}
+
+/* Converts a Node struct into a byte sequence.
+ * @param Node Node to convert.
+ * @param msgout Pointer to output buffer. Must be as long as a Node struct.
+ */
+void CanAutoNode::msgFromNode(Node node, uint8_t *msgout) {
+
+	memcpy(msgout,&node,sizeof(Node));
+
+
+}
+
+CanAutoNode::CanAutoNode() {
+}
+
+/* Send a message to a given board, starting from the beginning of its CAN ID range.
+ * If the message is too long for a single frame, will use multiple IDs.
+ * The message must not be too long to fit in the board's claimed range.
+ * @param boardID The unique board ID to send the message to. Must exist in the network.
+ * @param msg Message to send.
+ * @param len Length of message in bytes.
+ * @return true if successfully sent.
+ */
+bool CanAutoNode::SendMessageToDaughterBoardByCANIDOffset(UniqueBoardID boardID, const uint8_t *msg,
+		uint16_t len, uint16_t CANIDOffset) {
+
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		const Node& thisNode = daughterNodes[i];
+		if(thisNode.uniqueID == boardID) {
+			if((len-1)/64u+1 > thisNode.canIDRange.end - thisNode.canIDRange.start) {
+				return false;
+			}
+			return controller->SendByMsgID(msg, len, thisNode.canIDRange.start + CANIDOffset);
+		}
+	}
+	return false;
+
+}
+
+/* Sends a message starting at a given CAN ID, regardless of which board has claimed it.
+ * @param startingCanID CAN ID to start the message at.
+ * @param msg Message to send.
+ * @param len Length of message in bytes.
+ * @return true if successfully sent.
+ */
+bool CanAutoNode::SendMessageByCANID(uint32_t startingCanID, const uint8_t *msg,
+		uint16_t len) {
+		return controller->SendByMsgID(msg, len, startingCanID);
+}
+
+CanAutoNode::UniqueBoardID CanAutoNode::GetThisBoardUniqueID() const {
+	UniqueBoardID out;
+	out.u0 = HAL_GetUIDw0();
+	out.u1 = HAL_GetUIDw1();
+	out.u2 = HAL_GetUIDw2();
+	return out;
+}
+
+/* Sends a message to every daughter node of a given user-defined board type by a log index.
+ * @param boardType The type to send to.
+ * @param logIndex The log index to use.
+ * @param msg The message to send. Size determined by the reserved log.
+ * @return true if successfully sent at least one message.
+ */
+bool CanAutoNode::SendMessageToAllBoardsOfTypeByLogIndex(uint8_t boardType,
+		uint8_t logIndex, const uint8_t *msg) {
+	bool foundOne = false;
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		const Node& thisNode = daughterNodes[i];
+		if(thisNode.boardType == boardType) {
+			if(SendMessageToDaughterByLogIndex(thisNode.uniqueID, logIndex, msg)) {
+				foundOne = true;
+			}
+		}
+	}
+	return foundOne;
+
+}
+
+#ifdef CANAUTONODEDEBUG
+void CanAutoNode::PrintBoardID(CanAutoNode::UniqueBoardID id) {
+	  for(uint16_t i = 0; i < sizeof(CanAutoNode::UniqueBoardID); i++) {
+		  SOAR_PRINT("%x",((const uint8_t*)(&id))[i]);
+		  if(i % 4 == 0 && i > 0 && i < sizeof(CanAutoNode::UniqueBoardID)-1) {
+			  SOAR_PRINT(" ");
+		  }
+	  }
+}
+#endif
+
+/* Broadcast a heartbeat to the entire network on the reserved heartbeat channel.
+ * The caller is responsible for checking for responses.
+ * @return true if successfully sent.
+ */
+bool CanAutoNode::SendHeartbeat() {
+
+	HeartbeatInfo beat;
+	beat.senderBoardID = thisNode.uniqueID;
+
+	uint8_t msg[sizeof(HeartbeatInfo)] = {};
+	memcpy(msg,&beat,sizeof(msg));
+	return controller->SendByLogIndex(msg, HEARTBEAT_ID);
+	//return controller->SendByMsgID(msg, sizeof(msg), HEARTBEAT_ID);
+
+}
+
+/* Sends a message to a daughter board by a log index on that daughter board. Can be called from
+ * the motherboard or another daughter board.
+ * @param boardID Unique board ID to send to.
+ * @param logIndex Index of the log on the target board to send.
+ * @param msg Message to send. Size is determined by the size of the log being sent.
+ * @return true if successfully sent.
+ */
+bool CanAutoNode::SendMessageToDaughterByLogIndex(UniqueBoardID boardID,
+		uint8_t logIndex, const uint8_t *msg) {
+	if(logIndex >= MAX_LOG_TYPES_PER_NODE) {
+		return false;
+	}
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		const Node& thisDaughter = daughterNodes[i];
+		if(thisDaughter.uniqueID == boardID) {
+			return controller->SendByMsgID(msg, thisDaughter.logSizesInBytes[logIndex], thisDaughter.logOffsetsInCANIDs[logIndex]+thisDaughter.canIDRange.start);
+		}
+	}
+	return false;
+}
+
+/* Sends a message to a board in a given slot number by the log index on that daughter board.
+ * @param slotNumber Slot to send to.
+ * @param logIndex Index of the log on the target board to send.
+ * @param msg Message to send. Size is determined by the size of the log being sent.
+ * @return true if successfully sent.
+ */
+bool CanAutoNode::SendMessageToSlotNumberByLogIndex(uint8_t slotNumber,
+		uint8_t logIndex, const uint8_t *msg) {
+
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		const Node& thisNode = daughterNodes[i];
+		if(thisNode.slotNumber == slotNumber) {
+			return SendMessageToDaughterByLogIndex(thisNode.uniqueID, logIndex, msg);
+		}
+	}
+	return false;
+}
+
+/* Sends a message to a daughter board going by a given readable name (case-sensitive).
+ * @param targetName A null-terminated name of the board to send to.
+ * @param logIndex The index of the log to send.
+ * @param msg The message to send. Size is determined by the log being sent.
+ * @return true if successfully sent.
+ */
+bool CanAutoNode::SendMessageToNameByLogIndex(const char *targetName,
+		uint8_t logIndex, const uint8_t *msg) {
+
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		const Node& thisNode = daughterNodes[i];
+		if(strcmp(targetName, thisNode.nodeName) == 0) {
+			return SendMessageToDaughterByLogIndex(thisNode.uniqueID, logIndex, msg);
+		}
+	}
+	return false;
+}
+
+bool CanAutoNode::ReadMessageFromRXBuf(uint8_t logIndex, uint16_t logSize, uint8_t *out,
+		uint16_t outLen) {
+	// because of restrictive FDCAN size rounding, the output buffer may sometimes be
+	// padded with zeroes that need to be removed
+	uint16_t paddedSize = FDCanController::FDRoundDataSize(logSize);
+	if(paddedSize > outLen) {
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Log must be trimmed to fit in buffer\n");
+#endif
+		if(logSize > outLen) {
+#ifdef CANAUTONODEDEBUG
+			SOAR_PRINT("Could not read msg, buffer too small!\n");
+#endif
+			return false;
+		}
+		uint8_t paddedOut[paddedSize];
+		if(!controller->ReceiveLogIndexFromRXBuf(paddedOut, logIndex)) {
+			return false;
+		}
+		memcpy(out,paddedOut,logSize);
+		return true;
+	}
+
+#ifdef CANAUTONODEDEBUG
+	//SOAR_PRINT("Buffer large enough, attempting read...\n");
+#endif
+	return (controller->ReceiveLogIndexFromRXBuf(out, logIndex));
+}
+
+bool CanAutoNode::BoardExistsWithName(const char* name) {
+	if(strcmp(thisNode.nodeName,name)==0) {
+		return true;
+	}
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		if(strcmp(daughterNodes[i].nodeName,name)==0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+uint16_t CanAutoNode::GetNamesOfAllBoards(char(* outputArr)[MAX_NAME_STR_LEN], uint16_t outputArrayLen) {
+	uint16_t num = 0;
+	strncpy(outputArr[num++],thisNode.nodeName,MAX_NAME_STR_LEN);
+	//
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		strncpy(outputArr[num++],daughterNodes[i].nodeName,MAX_NAME_STR_LEN);
+		if(num >= outputArrayLen) {
+			break;
+		}
+	}
+
+	return num;
+
+}
+
+uint16_t CanAutoNode::GetIDsOfAllBoards(CanAutoNode::UniqueBoardID* outputArr, uint16_t outputArrayLen) {
+	uint16_t num = 0;
+	outputArr[num++] = thisNode.uniqueID;
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		outputArr[num++] = daughterNodes[i].uniqueID;
+		if(num >= outputArrayLen) {
+			break;
+		}
+	}
+
+	return num;
+
+}
+
+CanAutoNode::UniqueBoardID CanAutoNode::GetIDOfBoardWithName(const char* name) {
+
+	if(strcmp(thisNode.nodeName,name) == 0) {
+		return thisNode.uniqueID;
+	}
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		const auto node = daughterNodes[i];
+		if(strcmp(name,node.nodeName) == 0) {
+			return node.uniqueID;
+		}
+	}
+	return {0};
+}
+
+uint16_t CanAutoNode::GetNumberOfLogIndicesInBoard(UniqueBoardID board) {
+	if(board == thisNode.uniqueID) {
+		return thisNode.numberOfLogs;
+	}
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		const Node& thisNode = daughterNodes[i];
+		if(thisNode.uniqueID == board) {
+			return thisNode.numberOfLogs;
+		}
+	}
+	return 0;
+
+}
+
+uint16_t CanAutoNode::GetSizeOfLogIndexInBoard(UniqueBoardID board, uint16_t logindex) {
+	if(board == thisNode.uniqueID) {
+		return thisNode.logSizesInBytes[logindex];
+	}
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		const Node& thisNode = daughterNodes[i];
+		if(thisNode.uniqueID == board) {
+			return thisNode.logSizesInBytes[logindex];
+		}
+	}
+	return 0;
+}
+#ifdef FDCAN_DEBUG
+
+void CanAutoNode::ReportIDsReceived() {
+	controller->ReportIDsReceived();
+}
+
+uint32_t CanAutoNode::GetTicksSinceLastIDReceivePrint() {
+	return controller->GetTicksSinceLastIDReceivePrint();
+}
+
+#endif

--- a/CanAutoNode/CanAutoNode.hpp
+++ b/CanAutoNode/CanAutoNode.hpp
@@ -1,0 +1,188 @@
+/*
+ * CanAutoNode.h
+ *
+ *  Created on: Jul 16, 2025
+ *      Author: Adam Godin
+ */
+
+#ifndef AUTONODE_CANAUTONODE_HPP_
+#define AUTONODE_CANAUTONODE_HPP_
+
+/*
+ * Define this to enable debug prints across the driver. Uses SOAR_PRINT.
+ */
+//#define CANAUTONODEDEBUG
+
+#include "FDCan.h"
+#include <cstring>
+#include <random>
+
+constexpr uint32_t MAX_NODES_IN_NETWORK = 100;
+constexpr uint8_t MAX_LOG_TYPES_PER_NODE = 5;
+constexpr uint8_t MAX_NAME_STR_LEN = 20;
+constexpr uint8_t MAX_JOIN_ATTEMPTS = 8;
+// Max 2047 for 11-bit standard FDCAN, max 536,870,911 for extended FDCAN.
+// See transceiver and board capabilities before changing.
+constexpr uint16_t MAX_CAN_ID = 2047;
+
+// Reserved CAN IDs
+constexpr uint16_t JOIN_REQUEST_ID = 0;
+constexpr uint16_t ACK_ID = 1;
+constexpr uint16_t UPDATE_ID = 2;
+constexpr uint16_t KICK_REQUEST_ID = 3;
+constexpr uint16_t HEARTBEAT_ID = 4;
+constexpr uint16_t MAX_RESERVED_CAN_ID = 4; // Make sure to update if adding a new reserved ID
+
+
+#ifdef CANAUTONODEDEBUG
+//#include "Task.hpp"
+//#include "SystemDefines.hpp"
+#endif
+
+class CanAutoNode {
+public:
+	CanAutoNode();
+	//CanAutoNode(FDCanController& contr, uint16_t msgIDsToRequestStartID, uint16_t msgIDsToRequestAmount);
+
+	~CanAutoNode();
+	CanAutoNode& operator=(CanAutoNode &&other) = delete;
+	CanAutoNode(CanAutoNode &&other) = delete;
+	CanAutoNode& operator=(const CanAutoNode &other) = delete;
+
+
+	enum updateType {
+		CAN_UPDATE_DAUGHTER,
+		CAN_UPDATE_LAST_DAUGHTER,
+		CAN_UPDATE_MOTHERBOARD
+	};
+	enum acknowledgementStatus {
+		ACK_GOOD,
+		ACK_NO_ROOM,
+		ACK_BOARD_ALREADY_EXISTS
+	};
+
+	virtual bool CheckCANCommands() = 0;
+
+	struct UniqueBoardID {
+		uint32_t u0;
+		uint32_t u1;
+		uint32_t u2;
+
+		bool operator==(const UniqueBoardID&) const = default;
+		bool operator!=(const UniqueBoardID&) const = default;
+
+	};
+
+	bool SendMessageToDaughterByLogIndex(UniqueBoardID boardID, uint8_t logIndex, const uint8_t* msg);
+	bool SendMessageToAllBoardsOfTypeByLogIndex(uint8_t boardType, uint8_t logIndex, const uint8_t* msg);
+	bool SendMessageToSlotNumberByLogIndex(uint8_t slotNumber, uint8_t logIndex, const uint8_t* msg);
+	bool SendMessageToNameByLogIndex(const char* targetName, uint8_t logIndex, const uint8_t* msg);
+	bool SendMessageByCANID(uint32_t startingCanID, const uint8_t* msg, uint16_t len);
+	bool SendMessageToDaughterBoardByCANIDOffset(UniqueBoardID boardID, const uint8_t* msg, uint16_t len, uint16_t CANIDOffset);
+
+	UniqueBoardID GetThisBoardUniqueID() const;
+	UniqueBoardID GetIDOfBoardWithName(const char* name);
+	uint16_t GetNumberOfLogIndicesInBoard(UniqueBoardID board);
+	uint16_t GetSizeOfLogIndexInBoard(UniqueBoardID board, uint16_t logindex);
+
+	virtual uint16_t GetNumberOfNodesInNetwork() const = 0;
+
+	bool BoardExistsWithName(const char* name);
+
+	uint16_t GetNamesOfAllBoards(char(*outputArr)[MAX_NAME_STR_LEN], uint16_t outputBufferLen);
+	uint16_t GetIDsOfAllBoards(UniqueBoardID* outputArr, uint16_t outputBufferLen);
+
+#ifdef CANAUTONODEDEBUG
+	static void PrintBoardID(UniqueBoardID id);
+#endif
+
+#ifdef FDCAN_DEBUG
+	  void ReportIDsReceived();
+	  uint32_t GetTicksSinceLastIDReceivePrint();
+#endif
+protected:
+
+	struct IDRange {
+		uint32_t start = 0;
+		uint32_t end = 0;
+
+		bool operator==(const IDRange&) const = default;
+		bool operator!=(const IDRange&) const = default;
+	};
+
+	struct Node {
+		IDRange canIDRange;
+		UniqueBoardID uniqueID = {0};
+
+		uint8_t numberOfLogs = 0;
+		uint8_t boardType = 0;
+		uint8_t slotNumber = 0;
+
+		uint8_t logOffsetsInCANIDs[MAX_LOG_TYPES_PER_NODE];
+		uint8_t logSizesInBytes[MAX_LOG_TYPES_PER_NODE];
+
+		char nodeName[MAX_NAME_STR_LEN];
+
+		uint16_t startingLogIndexOnMotherboard = MAX_RESERVED_CAN_ID+1;
+
+		bool operator==(const Node&) const = default;
+		bool operator!=(const Node&) const = default;
+
+	};
+
+	static_assert(sizeof(Node) <= 64, "Node entries must be at most 64 bytes large. Try reducing MAX_LOGS");
+
+	struct HeartbeatInfo {
+		UniqueBoardID senderBoardID;
+	};
+
+	struct JoinRequest {
+		UniqueBoardID uniqueID;
+		uint8_t slotNumber;
+		uint8_t boardType;
+
+		char nodeName[MAX_NAME_STR_LEN];
+		uint8_t numberOfLogs;
+		uint8_t logSizesInBytes[MAX_LOG_TYPES_PER_NODE];
+	};
+
+	static_assert(sizeof(JoinRequest) <= 64, "Join request entries must be at most 64 bytes large. Try reducing MAX_LOGS");
+
+	FDCanController* controller = nullptr;
+	Node thisNode = {0};
+
+	static uint32_t shift8to32(const uint8_t* in);
+	static uint16_t shift8to16(const uint8_t *in);
+	static void shift32to8(uint32_t in, uint8_t* out);
+
+	static bool IDRangesOverlap(IDRange a, IDRange b);
+
+	static Node nodeFromMsg(const uint8_t* msg);
+	static void msgFromNode(Node node, uint8_t* msgout);
+
+	Node daughterNodes[MAX_NODES_IN_NETWORK];
+	uint16_t nodesInNetwork = 0;
+
+	bool SendHeartbeat();
+
+	template <typename T>
+	static void DataToMsg(T data, uint8_t* out) {
+		memcpy(out,&data,sizeof(T));
+	}
+
+	template <typename T>
+	static T MsgToData(const uint8_t* in) {
+		T out;
+		memcpy(&out,in,sizeof(T));
+		return out;
+	}
+
+	bool ReadMessageFromRXBuf(uint8_t logIndex, uint16_t logSize, uint8_t* out, uint16_t outLen);
+
+private:
+	CanAutoNode(const CanAutoNode &other) = delete;
+
+
+};
+
+#endif /* AUTONODE_CANAUTONODE_HPP_ */

--- a/CanAutoNode/CanAutoNodeDaughter.cpp
+++ b/CanAutoNode/CanAutoNodeDaughter.cpp
@@ -1,0 +1,383 @@
+#include <CanAutoNodeDaughter.hpp>
+#include <cstring>
+
+
+
+
+/* Gets the state of this daughter board.
+ * @return The current state.
+ */
+const CanAutoNodeDaughter::daughterState CanAutoNodeDaughter::GetCurrentState() const {
+	return currentState;
+}
+
+/* Attempt to join the network. Will block until all attempts fail or an acknowledgment is received.
+ * @return true if a positive acknowledgment is received.
+ */
+bool CanAutoNodeDaughter::TryRequestingJoiningNetwork() {
+
+	if(GetCurrentState() != UNINITIALIZED) {
+		return false;
+	}
+	srand(GetThisBoardUniqueID().u1);
+	uint16_t tries = 0;
+
+	while(1) {
+		if(!RequestToJoinNetwork()) {
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Failed try %d/%d\n",tries+1,MAX_JOIN_ATTEMPTS);
+#endif
+			HAL_Delay(rand()%500+100);
+			tries++;
+			if(tries >= MAX_JOIN_ATTEMPTS) {
+				ChangeState(ERROR);
+				return false;
+			}
+			ChangeState(REQUESTED_FAILED_WAITING_TO_RETRY);
+		} else {
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Successfully sent request\n");
+#endif
+			ChangeState(REQUESTED_WAITING_FOR_RESPONSE);
+			HAL_Delay(rand()%500+100);
+			if(CheckForAcknowledgement()) {
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Received good ACK\n");
+#endif
+				return true;
+			} else {
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Non good ACK received\n");
+#endif
+				ChangeState(REQUESTED_FAILED_WAITING_TO_RETRY);
+			}
+		}
+	}
+
+}
+
+/* Send a request to join the network on the reserved join request CAN ID.
+ * @return true if request successfully sent.
+ */
+bool CanAutoNodeDaughter::RequestToJoinNetwork() {
+
+	JoinRequest request;
+	request.uniqueID = thisNode.uniqueID;
+	request.boardType = thisNode.boardType;
+	request.slotNumber = thisNode.slotNumber;
+	request.numberOfLogs = numLogs;
+	for(uint16_t i = 0; i < numLogs; i++) {
+		request.logSizesInBytes[i] = (logsToInit[i].sizeInBytes);
+	}
+	strncpy(request.nodeName,thisNode.nodeName,MAX_NAME_STR_LEN);
+
+#ifdef CANAUTONODEDEBUG
+	SOAR_PRINT("requesting to join with my id: ");
+	PrintBoardID(request.uniqueID);
+	SOAR_PRINT(", number of logs: %d\n",request.numberOfLogs);
+#endif
+	uint8_t msg[sizeof(JoinRequest)];
+	DataToMsg<JoinRequest>(request, msg);
+
+	return controller->SendByMsgID(msg, sizeof(msg), JOIN_REQUEST_ID);
+}
+
+CanAutoNodeDaughter::~CanAutoNodeDaughter() {
+
+}
+
+
+/* Exhausts the FIFO until any acknowledgment is received.
+ * return true if a good acknowledgment is found.
+ */
+bool CanAutoNodeDaughter::CheckForAcknowledgement() {
+	if(GetCurrentState() != REQUESTED_WAITING_FOR_RESPONSE) {
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Wasn't in the right state to check for ACK: we are in state %d\n",GetCurrentState());
+#endif
+		return false;
+	}
+	uint8_t msg[64] = {123};
+
+	while(controller->ReceiveLogIndexFromRXBuf(msg, ACK_ID)) {
+
+
+		acknowledgementStatus incomingStatus = static_cast<acknowledgementStatus>(msg[0]);
+		switch(incomingStatus) {
+		case ACK_GOOD:
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Good ACK!\n");
+#endif
+			controller->DiscardLog(KICK_REQUEST_ID); // So we don't immediately get kicked on rejoining after a daughter reset
+			ChangeState(WAITING_FOR_UPDATE);
+			return true;
+
+		case ACK_NO_ROOM:
+			ChangeState(ERROR);
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("No room!\n");
+#endif
+			return false;
+
+		default:
+			// invalid ack
+			ChangeState(ERROR);
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Invalid ACK!\n");
+#endif
+			return false;
+		}
+
+	}
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Didn't receive any ACK\n");
+#endif
+	// not received
+	return false;
+}
+
+
+/* Exhausts the FIFO until an update is found, or an update is partly received and times out.
+ * return true if successfully received update.
+ */
+bool CanAutoNodeDaughter::CheckForUpdate() {
+
+	if(GetCurrentState() != WAITING_FOR_UPDATE) {
+		return false;
+	}
+	uint8_t msg[64] = {123};
+
+	while(controller->ReceiveLogIndexFromRXBuf(msg, UPDATE_ID)) {
+
+
+		return ReceiveUpdate(msg);
+
+	}
+	// not received
+	if(HAL_GetTick() - tickLastReceivedUpdatePart > 1000) {
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Update timed out!\n");
+#endif
+		ChangeState(ERROR);
+	}
+	return false;
+
+}
+
+/* Exhausts the FIFO until kick, join, or heartbeat is encountered while ready.
+ * @return true if any are found.
+ */
+bool CanAutoNodeDaughter::ProcessMessage() {
+	if(GetCurrentState() != READY) {
+		return false;
+	}
+	uint8_t msg[64] = {};
+	bool gotOne = false;
+	while(controller->ReceiveLogIndexFromRXBuf(msg, KICK_REQUEST_ID)) {
+		gotOne = true;
+
+		UniqueBoardID kickedBoard = MsgToData<UniqueBoardID>(msg);
+		if(kickedBoard == this->thisNode.uniqueID) {
+#ifdef CANAUTONODEDEBUG
+			SOAR_PRINT("This node just got kicked!\n");
+#endif
+			ChangeState(UNINITIALIZED);
+			return true;
+		}
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Saw ");
+		PrintBoardID(kickedBoard);
+		SOAR_PRINT("just get kicked\n");
+#endif
+
+		ChangeState(WAITING_FOR_UPDATE);
+		gotOne = true;
+	}
+	while(controller->ReceiveLogIndexFromRXBuf(msg, JOIN_REQUEST_ID)) {
+
+
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Saw a join request from another board\n");
+#endif
+		ChangeState( WAITING_FOR_UPDATE);
+		gotOne = true;
+	}
+	while(controller->ReceiveLogIndexFromRXBuf(msg, HEARTBEAT_ID)) {
+
+
+		if(MsgToData<UniqueBoardID>(msg) == Motherboard.uniqueID) {
+#ifdef CANAUTONODEDEBUG
+			SOAR_PRINT("Received heartbeat\n");
+#endif
+			SendHeartbeat();
+		}
+		gotOne = true;
+	}
+
+
+	return gotOne;
+}
+
+/* Change the state, updating timeout timers.
+ * @param target The state to change to.
+ */
+void CanAutoNodeDaughter::ChangeState(daughterState target) {
+	currentState = target;
+#ifdef CANAUTONODEDEBUG
+	SOAR_PRINT("Changing state to %d\n",target);
+#endif
+	switch(target) {
+	case WAITING_FOR_UPDATE:
+		tickLastReceivedUpdatePart = HAL_GetTick();
+		nodesInNetwork = 0;
+		break;
+
+	case ERROR:
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT(">>>ERROR!\n");
+#endif
+		//intentional fallthrough
+	case UNINITIALIZED:
+		initializedLogs = false;
+		nodesInNetwork = 0;
+		thisNode.canIDRange = {0,0};
+		break;
+
+
+
+	default:
+		break;
+	}
+}
+
+/* @param fdcan Pointer to the autogenerated FDCAN peripheral.
+ * @param logs Pointer to an array of data types to be reserved in the network
+ * @param numLogs Number of entries in logs.
+ * @param boardType A user-defined byte to be stored with the board information.
+ * @param slotNumber The number of the slot the board is placed in.
+ * @param readableName An optional null-terminated string to identify the board. Can be nullptr.
+ */
+CanAutoNodeDaughter::CanAutoNodeDaughter(FDCAN_HandleTypeDef *fdcan, const LogInit *logs,
+		uint16_t numLogs, uint8_t boardType, uint8_t slotNumber, const char* readableName) {
+	controller = new FDCanController(fdcan,nullptr,0);
+
+	memcpy(logsToInit,logs,numLogs*sizeof(LogInit));
+	this->numLogs = numLogs;
+	callbackcontroller = controller;
+	currentState = UNINITIALIZED;
+	this->thisNode.canIDRange = {0,0};
+	this->thisNode.uniqueID = GetThisBoardUniqueID();
+	this->thisNode.boardType = boardType;
+	this->thisNode.slotNumber = slotNumber;
+	if(readableName != nullptr && strlen(readableName) > 0 && strlen(readableName) < MAX_NAME_STR_LEN) {
+		strcpy(this->thisNode.nodeName,readableName);
+	} else {
+		memset(this->thisNode.nodeName,0x00,MAX_NAME_STR_LEN);
+	}
+
+
+	//controller->RegisterFilterRXFIFO(0, MAX_RESERVED_CAN_ID);
+
+	FDCanController::LogInitStruct reservedLogs[] = {{64,JOIN_REQUEST_ID},{64,ACK_ID},{64,UPDATE_ID},{64,KICK_REQUEST_ID},{64,HEARTBEAT_ID}};
+	controller->RegisterLogs(reservedLogs, sizeof(reservedLogs)/sizeof(reservedLogs[0]));
+
+
+}
+
+/* Sends a message to the motherboard by the log index.
+ * @param logID The index of the log to send. Determines the size and type. Corresponds to the
+ * order of logs given during initialization.
+ * @param msg Data to send. Size must be at least as large as the log type being sent.
+ * @return true if sent successfully.
+ */
+bool CanAutoNodeDaughter::SendMessageToMotherboardByLogID(uint16_t logID, const uint8_t *msg) {
+	if(GetCurrentState() != READY) {
+		return false;
+	}
+	//printf("sending to motherboard log index %d\n",logID);
+	return controller->SendByLogIndex(msg, logID+MAX_RESERVED_CAN_ID+1);
+}
+
+/* Handle receiving part of an update, updating internal node references and changing state when ready.
+ * @param msg Update frame received.
+ * @return true if successfully received the update part.
+ */
+bool CanAutoNodeDaughter::ReceiveUpdate(const uint8_t *msg) {
+
+	tickLastReceivedUpdatePart = HAL_GetTick();
+
+	Node receivedNode = nodeFromMsg(msg+1);
+
+	switch(msg[0]) {
+
+	case CAN_UPDATE_LAST_DAUGHTER: // shouldn't have to worry about last and fsb being the same because the update will only be sent after a new node is added
+		ChangeState(READY);
+	case CAN_UPDATE_DAUGHTER:
+		if(receivedNode.uniqueID != thisNode.uniqueID) {
+			this->daughterNodes[this->nodesInNetwork++] = receivedNode;
+#ifdef CANAUTONODEDEBUG
+	SOAR_PRINT("Received update for someone else... initializedLogs: %d, numLogs: %d, according to the update numLogs: %d\n",initializedLogs,numLogs,receivedNode.numberOfLogs);
+
+#endif
+		} else {
+			this->thisNode = receivedNode;
+
+#ifdef CANAUTONODEDEBUG
+	SOAR_PRINT("Received update for me... initializedLogs: %d, numLogs: %d, according to the update numLogs: %d\n",initializedLogs,numLogs,receivedNode.numberOfLogs);
+
+#endif
+			if(!initializedLogs) {
+				uint16_t canid = receivedNode.canIDRange.start;
+				for(uint16_t i = 0; i < numLogs; i++) {
+					uint16_t requiredIDs = (logsToInit[i].sizeInBytes-1)/64+1;
+					determinedLogs[i] = {logsToInit[i].sizeInBytes, canid};
+					canid += requiredIDs;
+#ifdef CANAUTONODEDEBUG
+	SOAR_PRINT("Registering log %d at canid %d byte size %d\n",i,determinedLogs[i].startingMsgID,determinedLogs[i].byteLength);
+
+#endif
+
+				}
+				controller->RegisterLogs(determinedLogs, numLogs);
+
+				initializedLogs = true;
+			}
+
+		}
+#ifdef CANAUTONODEDEBUG
+	SOAR_PRINT("Received a daughter update part for ");
+	PrintBoardID(receivedNode.uniqueID);
+	SOAR_PRINT("\n");
+#endif
+		break;
+
+	case CAN_UPDATE_MOTHERBOARD:
+		this->Motherboard = receivedNode;
+#ifdef CANAUTONODEDEBUG
+	SOAR_PRINT("Received a motherboard update part for ");
+	PrintBoardID(receivedNode.uniqueID);
+	SOAR_PRINT("\n");
+#endif
+		break;
+
+	default:
+		return false;
+	}
+
+	return true;
+
+}
+
+bool CanAutoNodeDaughter::ReadMessageByLogIndex(uint8_t logIndex,
+		uint8_t *out, uint16_t outLen) {
+	if(GetCurrentState() != READY) {
+		return false;
+	}
+	uint16_t logSize = determinedLogs[logIndex].byteLength;
+	return ReadMessageFromRXBuf(logIndex+MAX_RESERVED_CAN_ID+1, logSize, out, outLen);
+
+}
+
+uint16_t CanAutoNodeDaughter::GetSizeOfLog(uint8_t logIndex) const {
+	return determinedLogs[logIndex].byteLength;
+}

--- a/CanAutoNode/CanAutoNodeDaughter.hpp
+++ b/CanAutoNode/CanAutoNodeDaughter.hpp
@@ -1,0 +1,98 @@
+#ifndef CANAUTONODEDAUGHTER_HPP_
+#define CANAUTONODEDAUGHTER_HPP_
+
+#include "FDCan.h"
+#include "CanAutoNode.hpp"
+
+
+class CanAutoNodeDaughter : public CanAutoNode {
+
+public:
+
+	struct LogInit {
+		uint16_t sizeInBytes;
+	};
+	enum daughterState {
+		UNINITIALIZED,
+		REQUESTED_WAITING_FOR_RESPONSE,
+		REQUESTED_FAILED_WAITING_TO_RETRY,
+		WAITING_FOR_UPDATE,
+		READY,
+		ERROR
+	};
+
+	//CanAutoNodeDaughter(FDCanController* contr, uint16_t msgIDsToRequestStartID, uint16_t msgIDsToRequestAmount);
+
+    CanAutoNodeDaughter(FDCAN_HandleTypeDef *fdcan,
+    		const LogInit *logs, uint16_t numLogs, uint8_t boardType, uint8_t slotNumber, const char* readableName);
+	~CanAutoNodeDaughter();
+	CanAutoNodeDaughter() = delete;
+
+	CanAutoNodeDaughter(const CanAutoNodeDaughter &) = delete;
+	CanAutoNodeDaughter &operator=(const CanAutoNodeDaughter &) = delete;
+
+
+	const daughterState GetCurrentState() const;
+
+
+	bool TryRequestingJoiningNetwork();
+
+	bool CheckCANCommands() override {
+		switch(currentState) {
+		case REQUESTED_WAITING_FOR_RESPONSE:
+			return CheckForAcknowledgement();
+		case WAITING_FOR_UPDATE:
+			return CheckForUpdate();
+		case READY:
+			return ProcessMessage();
+		default:
+			return false;
+		}
+	}
+
+	/* Gets the total number of nodes in the network, including the motherboard and this node.
+	 * Note that this is different from the size of the internal node table.
+	 */
+	uint16_t GetNumberOfNodesInNetwork() const override {
+		return nodesInNetwork+2;
+	}
+
+	bool SendMessageToMotherboardByLogID(uint16_t logID, const uint8_t* msg);
+
+	bool ReadMessageByLogIndex(uint8_t logIndex, uint8_t* out, uint16_t outLen);
+
+	uint16_t GetSizeOfLog(uint8_t logIndex) const;
+
+protected:
+
+
+	void ChangeState(daughterState target);
+
+//	uint32_t uniqueBoardID = HAL_GetDEVID();
+	Node Motherboard = {0};
+	bool CheckForAcknowledgement();
+	bool CheckForUpdate();
+	bool ProcessMessage();
+	bool CheckForHeartbeat();
+
+	daughterState currentState = UNINITIALIZED;
+
+	bool RequestToJoinNetwork();
+
+	bool ReceiveUpdate(const uint8_t* msg);
+
+	uint32_t tickLastReceivedUpdatePart = 0;
+
+	LogInit logsToInit[MAX_LOG_TYPES_PER_NODE];
+	uint16_t numLogs;
+
+	FDCanController::LogInitStruct determinedLogs[MAX_LOG_TYPES_PER_NODE];
+
+	bool initializedLogs = false;
+
+//	const uint8_t boardType;
+//	const IDRange idRange;
+
+};
+
+#endif

--- a/CanAutoNode/CanAutoNodeMotherboard.cpp
+++ b/CanAutoNode/CanAutoNodeMotherboard.cpp
@@ -1,0 +1,464 @@
+#include <CanAutoNodeMotherboard.hpp>
+#include <cstring>
+
+/* Kicks a board out of the network, updating the table, and sending an update to all remaining nodes.
+ * @param uniqueBoardID Board to kick.
+ * @return true if successful,
+ */
+bool CanAutoNodeMotherboard::KickNode(UniqueBoardID uniqueBoardID) {
+
+	bool exists = false;
+	uint16_t foundIndex = 0;
+
+
+
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		const Node& thisNode = daughterNodes[i];
+		if(thisNode.uniqueID == uniqueBoardID) {
+			exists = true;
+			foundIndex = i;
+			break;
+		}
+	}
+
+	if(!exists) {
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Tried to kick node, but doesn't exist! (Attempted to kick ");
+		PrintBoardID(uniqueBoardID);
+		SOAR_PRINT(")\nNow just forcing send kick\n");
+#endif
+
+
+
+
+		//return true;
+	} else {
+
+	// to get rid of this node, first we will identify the MOTHERBOARD log indexes to remove ON THE MOTHERBOARD
+	uint8_t indicesToRemove[daughterNodes[foundIndex].numberOfLogs];
+	for(uint8_t i = 0; i < daughterNodes[foundIndex].numberOfLogs; i++) {
+		indicesToRemove[i] = daughterNodes[foundIndex].startingLogIndexOnMotherboard+i;
+	}
+	controller->RemoveLogIndices(indicesToRemove, sizeof(indicesToRemove)/sizeof(indicesToRemove[0]));
+	nextFreeMotherboardLogIndex -= daughterNodes[foundIndex].numberOfLogs;
+
+	// next, we shall update all other nodes to shift their motherboard log index offsets down to fill in the gap.
+	// this change will be reflected to all remaining daughters in the upcoming update
+	// note that this does not reassign can ids. this is fine, now that this node is gone its space in the
+	//can address space is freed and can be reassigned. i dont care about fragmentation, if you are connecting and kicking over 2000 nodes in a random order, there is some other problem
+	for(uint8_t i = 0; i < nodesInNetwork; i++) {
+		if(i != foundIndex && daughterNodes[i].startingLogIndexOnMotherboard > daughterNodes[foundIndex].startingLogIndexOnMotherboard) {
+			daughterNodes[i].startingLogIndexOnMotherboard -= daughterNodes[foundIndex].numberOfLogs;
+		}
+
+	}
+
+	// now actually remove the kicked node
+	daughterNodes[foundIndex] = daughterNodes[--nodesInNetwork];
+
+	for(uint16_t i = 0; i < recentlyJoinedNum; i++) {
+		if(recentlyJoined[i]->uniqueID == uniqueBoardID) {
+			recentlyJoined[i] = recentlyJoined[--recentlyJoinedNum];
+			break;
+		}
+	}
+
+	heartbeatGracePeriod[foundIndex] = heartbeatGracePeriod[nodesInNetwork];
+	}
+	if(!controller->SendByMsgID((uint8_t*)(&uniqueBoardID), sizeof(uniqueBoardID), KICK_REQUEST_ID)) {
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Tried to kick node, but failed to send! (Attempted to kick ");
+		PrintBoardID(uniqueBoardID);
+		SOAR_PRINT(")\n");
+#endif
+		return false;
+	}
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Kicked node (");
+		PrintBoardID(uniqueBoardID);
+		SOAR_PRINT(")\n");
+#endif
+
+
+	return SendFullUpdate();
+}
+
+/* Kicks a board out of the network with a given name, updating the table, and sending an update to all remaining nodes.
+ * @param uniqueBoardID Board to kick.
+ * @return true if successful,
+ */
+bool CanAutoNodeMotherboard::KickNode(const char *boardName) {
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		const Node& thisNode = daughterNodes[i];
+		if(strcmp(thisNode.nodeName,boardName) == 0) {
+			return KickNode(thisNode.uniqueID);
+		}
+	}
+	return false;
+}
+
+/* Kicks a board out of the network in a given slot number, updating the table, and sending an update to all remaining nodes.
+ * @param uniqueBoardID Board to kick.
+ * @return true if successful,
+ */
+bool CanAutoNodeMotherboard::KickNode(uint16_t slotNumber) {
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		const Node& thisNode = daughterNodes[i];
+		if(thisNode.slotNumber == slotNumber) {
+			return KickNode(thisNode.uniqueID);
+		}
+	}
+	return false;
+}
+
+CanAutoNodeMotherboard::CanAutoNodeMotherboard(FDCAN_HandleTypeDef *fdcan) {
+	controller = new FDCanController(fdcan,nullptr,0);
+	callbackcontroller = controller;
+	//controller->RegisterFilterRXFIFO(0, MAX_RESERVED_CAN_ID);
+	memset(heartbeatGracePeriod,0x00,sizeof(heartbeatGracePeriod));
+
+	FDCanController::LogInitStruct reservedLogs[] = {{64,JOIN_REQUEST_ID},{64,ACK_ID},{64,UPDATE_ID},{64,KICK_REQUEST_ID},{64,HEARTBEAT_ID}};
+	controller->RegisterLogs(reservedLogs, sizeof(reservedLogs)/sizeof(reservedLogs[0]));
+}
+
+
+
+/* Exhausts the FIFO until a join request is found and processed.
+ * @return true if one was found and processed successfully.
+ */
+bool CanAutoNodeMotherboard::CheckForJoinRequest() {
+
+	uint8_t msg[64] = {123};
+	uint32_t id = 0;
+
+
+	while(controller->ReceiveLogIndexFromRXBuf(msg, JOIN_REQUEST_ID)) {
+
+		return ReceiveJoinRequest(msg);
+
+	}
+	// not received
+	return false;
+
+}
+
+/* Attempts to incorporate a new node into the network. Will assign the new node a
+ * consecutive range of CAN IDs of the requested size. Sends an acknowledgment, followed by a
+ * complete update if successful.
+ * @param msg The join request received.
+ * @return true if successfully added the node and send an update.
+ */
+bool CanAutoNodeMotherboard::ReceiveJoinRequest(uint8_t* msg) {
+
+
+	JoinRequest request = MsgToData<JoinRequest>(msg);
+#ifdef CANAUTONODEDEBUG
+	SOAR_PRINT("Received a join request from ");
+	PrintBoardID(request.uniqueID);
+	SOAR_PRINT("\n");
+#endif
+	uint16_t requiredTotalCANIDs = 0;
+	for(uint16_t i = 0; i < request.numberOfLogs; i++) {
+		requiredTotalCANIDs += (request.logSizesInBytes[i]-1)/64+1;
+	}
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		const Node& thisAlreadyExistingNode = daughterNodes[i];
+
+		if(request.uniqueID == thisAlreadyExistingNode.uniqueID) {
+			// already have this board somehow
+			SendAck(ACK_BOARD_ALREADY_EXISTS);
+			return false;
+		}
+
+	}
+
+
+	// Finding smallest possible gap to fit the newly requested ID range into
+	Node sortedNodes[nodesInNetwork];
+	memcpy(sortedNodes,daughterNodes,sizeof(sortedNodes));
+
+	auto comp = [](const void* a, const void* b) {
+		return static_cast<int>(static_cast<const Node*>(a)->canIDRange.start - static_cast<const Node*>(b)->canIDRange.start);
+	};
+	qsort(sortedNodes, nodesInNetwork, sizeof(Node), comp);
+
+
+	uint32_t bestStartingFreeCANID = 0;
+	bool foundRoom = false;
+	uint16_t bestAmountOfRoom = MAX_CAN_ID;
+	uint32_t previousEnd = MAX_RESERVED_CAN_ID+1;
+
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		const Node& thisNode = sortedNodes[i];
+		uint16_t thisAmountOfRoom = thisNode.canIDRange.start-previousEnd;
+
+		if(thisAmountOfRoom < bestAmountOfRoom && thisAmountOfRoom >= requiredTotalCANIDs) {
+			bestAmountOfRoom = thisAmountOfRoom;
+			bestStartingFreeCANID = previousEnd;
+			foundRoom = true;
+		}
+		previousEnd = thisNode.canIDRange.end;
+	}
+
+	uint16_t thisAmountOfRoom = MAX_CAN_ID-previousEnd;
+
+	if(thisAmountOfRoom < bestAmountOfRoom && thisAmountOfRoom >= requiredTotalCANIDs) {
+		bestAmountOfRoom = thisAmountOfRoom;
+		bestStartingFreeCANID = previousEnd;
+		foundRoom = true;
+	}
+
+
+	if(foundRoom)  {
+		// found no issues
+		SendAck(ACK_GOOD);
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Adding new node at ID range [%d,%d)\n",bestStartingFreeCANID,bestStartingFreeCANID+requiredTotalCANIDs);
+#endif
+		Node newNode;
+		newNode = {{bestStartingFreeCANID,bestStartingFreeCANID+requiredTotalCANIDs}, // 1 too many?
+				request.uniqueID,
+				request.numberOfLogs,
+				request.boardType,
+				request.slotNumber};
+		strncpy(newNode.nodeName,request.nodeName,MAX_NAME_STR_LEN);
+
+		FDCanController::LogInitStruct newLogs[request.numberOfLogs];
+		uint16_t thisID = bestStartingFreeCANID;
+		for(uint16_t i = 0; i < request.numberOfLogs; i++) {
+			newLogs[i] = {request.logSizesInBytes[i], thisID};
+			newNode.logOffsetsInCANIDs[i] = thisID - bestStartingFreeCANID;
+			newNode.logSizesInBytes[i] = request.logSizesInBytes[i];
+			thisID += (request.logSizesInBytes[i]-1)/64+1;
+
+		}
+		daughterNodes[nodesInNetwork] = newNode;
+		recentlyJoined[recentlyJoinedNum++] = &daughterNodes[nodesInNetwork];
+		controller->RegisterLogs(newLogs, request.numberOfLogs);
+		heartbeatGracePeriod[nodesInNetwork] = 0;
+		nodesInNetwork++;
+		newNode.startingLogIndexOnMotherboard = nextFreeMotherboardLogIndex;
+		nextFreeMotherboardLogIndex += request.numberOfLogs;
+
+
+		HAL_Delay(50);
+		return SendFullUpdate();
+	} else {
+		SendAck(ACK_NO_ROOM);
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("No room for new node!\n");
+#endif
+		return false;
+	}
+
+}
+
+/* Sends an acknowledgment to the network.
+ * @apram status The acknowledgment to send.
+ * @return true if successfully sent.
+ */
+bool CanAutoNodeMotherboard::SendAck(acknowledgementStatus status) {
+
+	uint8_t msg[] = {static_cast<uint8_t>(status)};
+	return controller->SendByMsgID(msg, sizeof(msg), ACK_ID);
+
+}
+
+
+/* Sends a full list of all nodes in the network to all nodes. Serves to keep
+ * daughter nodes up-to-date with the network contents.
+ * Sends in multiple frames, where each frame contains one node preceded by a status byte,
+ * denoting whether the frame is a daughter node or the motherboard node, and whether it is the
+ * last frame in the update.
+ * @return true if successful.
+ */
+bool CanAutoNodeMotherboard::SendFullUpdate() {
+
+	uint8_t msg[sizeof(Node)+1];
+	msgFromNode(thisNode, msg+1);
+	msg[0] = CAN_UPDATE_MOTHERBOARD;
+
+	if(!controller->SendByMsgID(msg, sizeof(msg), UPDATE_ID)) {
+#ifdef CANAUTONODEDEBUG
+	SOAR_PRINT("Failed to send motherboard update frame!\n");
+#endif
+		return false;
+	}
+#ifdef CANAUTONODEDEBUG
+	SOAR_PRINT("Sent motherboard update frame\n");
+#endif
+
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		msgFromNode(daughterNodes[i], msg+1);
+		msg[0] = (i == nodesInNetwork-1) ? CAN_UPDATE_LAST_DAUGHTER : CAN_UPDATE_DAUGHTER;
+		if(!controller->SendByMsgID(msg, sizeof(msg), UPDATE_ID)) {
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Tried but failed to send daughter update frame!\n");
+#endif
+			return false;
+		}
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Sent daughter update frame %d/%d\n",i+1,nodesInNetwork);
+#endif
+	}
+
+	return true;
+
+}
+
+/* Sends a heartbeat, then monitors for responses. Will wait up to one second.
+ * Any nodes that do not respond within this time will be kicked.
+ * @return true if heartbeat successfully sent.
+ */
+bool CanAutoNodeMotherboard::Heartbeat() {
+
+	this->lastHeartbeatTick = HAL_GetTick();
+
+	if(!SendHeartbeat()) {
+		return false;
+	}
+
+
+
+	bool received[nodesInNetwork];
+	memset(received,0,sizeof(received));
+
+	for(uint16_t i = 0; i < 1000; i++) {
+		HAL_Delay(1);
+		uint8_t out[64];
+		uint32_t id = 0;
+		if(controller->ReceiveLogIndexFromRXBuf(out, HEARTBEAT_ID)) {
+
+
+				UniqueBoardID responseID = MsgToData<UniqueBoardID>(out);
+				bool foundResponder = false;
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Got a heartbeat from ");
+		PrintBoardID(responseID);
+		SOAR_PRINT(", there are %d daughter nodes in the network\n",nodesInNetwork);
+#endif
+				for(int node = 0; node < nodesInNetwork; node++) {
+					if(daughterNodes[node].uniqueID == responseID) {
+						if(received[node]) {
+							// received multiple heartbeats from the same node?
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Received multiple heartbeats from ");
+		PrintBoardID(responseID);
+		SOAR_PRINT(", kicking\n");
+#endif
+							KickNode(responseID);
+						}
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Found the source of this heartbeat at %d!\n",node);
+#endif
+						received[node] = true;
+						foundResponder = true;
+						break;
+					}
+				}
+				bool gotAllOfThem = true;
+				for(uint8_t j = 0; j < nodesInNetwork; j++) {
+					if(!received[j]) {
+						gotAllOfThem = false;
+						break;
+					}
+				}
+
+				if(!foundResponder) {
+					// ??? a node that wasn't in the network just responded to the heartbeat?  get out
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Received heartbeat from unrecognized node ");
+		PrintBoardID(responseID);
+		SOAR_PRINT(", kicking\n");
+#endif
+					KickNode(responseID);
+				}
+
+
+				if(gotAllOfThem) {
+						return true; // just leave early, we got all the responses
+					}
+
+
+
+
+		}
+		if(i > 10 && nodesInNetwork == 0) {
+			return true; // don't bother waiting the whole timeout when there are no daughter nodes, we just want to see if there are any out-of-network responders
+		}
+	}
+
+	for(size_t i = 0; i < nodesInNetwork; i++) {
+		if(!received[i]) { // Found a node that never responded to the heartbeat
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Received no heartbeat from ");
+		PrintBoardID(daughterNodes[i].uniqueID);
+		SOAR_PRINT(", kicking\n");
+#endif
+		if(heartbeatGracePeriod[i] > 0) {
+			heartbeatGracePeriod[i]--;
+		} else {
+			KickNode(daughterNodes[i].uniqueID);
+		}
+		}
+	}
+
+	return true;
+
+}
+
+uint32_t CanAutoNodeMotherboard::GetTicksSinceLastHeartbeat() const {
+	return HAL_GetTick() - lastHeartbeatTick;
+}
+
+/*
+ * Reads an incoming message from a daughter node on a given log index.
+ */
+bool CanAutoNodeMotherboard::ReadMessageFromDaughterByLogIndex(
+		UniqueBoardID daughter, uint8_t logIndex, uint8_t *out,
+		uint16_t outSize) {
+
+	for(uint16_t i = 0; i < nodesInNetwork; i++) {
+		const Node& thisNode = daughterNodes[i];
+		if(thisNode.uniqueID == daughter) {
+
+		if(logIndex >= thisNode.numberOfLogs) {
+#ifdef CANAUTONODEDEBUG
+		SOAR_PRINT("Cannot read log index %d from daughter with max index %d",logIndex,thisNode.numberOfLogs);
+#endif
+			return false;
+		}
+			return ReadMessageFromRXBuf(thisNode.startingLogIndexOnMotherboard+logIndex, thisNode.logSizesInBytes[logIndex], out, outSize);
+		}
+	}
+#ifdef CANAUTONODEDEBUG
+	SOAR_PRINT("No node with that ID!\n");
+#endif
+	return false;
+
+}
+
+/* Returns an array of name strings of any boards that joined the network since the last call of this function.
+ * @param outputArr A pointer to an array of char arrays to store the names.
+ * @param outputBufferLen For safety, will not write more entries than this to the output.
+ * @return The number of nodes returned in the array.
+ *
+ */
+uint16_t CanAutoNodeMotherboard::GetNamesOfNewlyJoinedBoards(char(*outputArr)[MAX_NAME_STR_LEN], uint16_t outputBufferLen) {
+
+	if(recentlyJoinedNum == 0) {
+		return 0;
+	}
+
+	uint16_t num = 0;
+	for(uint16_t i = 0; i < recentlyJoinedNum; i++) {
+		strncpy(outputArr[num++],daughterNodes[i].nodeName,MAX_NAME_STR_LEN);
+		if(i >= outputBufferLen) {
+			break;
+		}
+
+	}
+	memcpy(recentlyJoined,&recentlyJoined[recentlyJoinedNum-num],(num)*sizeof(Node*));
+	recentlyJoinedNum -= num;
+
+}

--- a/CanAutoNode/CanAutoNodeMotherboard.hpp
+++ b/CanAutoNode/CanAutoNodeMotherboard.hpp
@@ -1,0 +1,55 @@
+#ifndef CANAUTONODEMOTHERBOARD_HPP_
+#define CANAUTONODEMOTHERBOARD_HPP_
+#include "FDCan.h"
+#include "CanAutoNode.hpp"
+
+class CanAutoNodeMotherboard : public CanAutoNode {
+
+public:
+
+
+	CanAutoNodeMotherboard(FDCAN_HandleTypeDef *fdcan);
+
+	bool CheckCANCommands() override {
+		return CheckForJoinRequest();
+	}
+	bool KickNode(UniqueBoardID uniqueBoardID);
+	bool KickNode(const char* boardName);
+	bool KickNode(uint16_t slotNumber);
+
+	bool Heartbeat();
+
+	uint32_t GetTicksSinceLastHeartbeat() const;
+
+	/* Gets the total number of nodes in the network, including the motherboard.
+	 * Note that this is different from the size of the internal node table.
+	 */
+	uint16_t GetNumberOfNodesInNetwork() const override {
+		return nodesInNetwork+1;
+	}
+
+	bool ReadMessageFromDaughterByLogIndex(UniqueBoardID daughter, uint8_t logIndex, uint8_t *out, uint16_t outSize);
+
+	uint16_t GetNamesOfNewlyJoinedBoards(char(*outputArr)[MAX_NAME_STR_LEN], uint16_t outputBufferLen);
+
+private:
+	bool ReceiveJoinRequest(uint8_t* msg);
+
+	bool SendAck(acknowledgementStatus status);
+
+	bool SendFullUpdate();
+
+	bool CheckForJoinRequest();
+
+	uint32_t lastHeartbeatTick = 0;
+
+	uint16_t nextFreeMotherboardLogIndex = 0;
+
+	Node* recentlyJoined[MAX_NODES_IN_NETWORK];
+	uint16_t recentlyJoinedNum = 0;
+
+	uint8_t heartbeatGracePeriod[MAX_NODES_IN_NETWORK];
+
+};
+
+#endif


### PR DESCRIPTION
The high-level communication protocol for inter-board FDCAN communication. Depends on one of the base FDCAN drivers from PeripheralDriversSubmodule, either the G4 or the H7 version.